### PR TITLE
Fix `make docker-image-build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,8 @@ FROM archlinux:latest
 
 SHELL ["/usr/bin/bash", "-c"]
 
-# Update system and install base packages
-# Fix: archlinux:latest has corrupt pacman local db (missing desc files in overlay)
-# Step 1: upgrade base system (creates new layer, fixes stale db entries)
-RUN pacman-db-upgrade 2>/dev/null; \
-    for pkg in /var/lib/pacman/local/*/; do \
-      [ ! -f "${pkg}desc" ] && rm -rf "$pkg" 2>/dev/null; \
-    done; true
+# Step 1: disable sandbox
+RUN echo "DisableSandbox" >> /etc/pacman.conf
 RUN pacman -Syu --noconfirm
 # Step 2: clean stale entries from previous layer, then install build deps
 RUN for pkg in /var/lib/pacman/local/*/; do \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ docker-shell: COMMAND=bash
 # The build user must also be a member of the "docker" group.
 docker-image-build:
 	$(DOCKER_CMD) buildx create --use
-	$(DOCKER_CMD) buildx build --tag $(DOCKER_IMAGE) --platform $(shell if [ "$$(uname -m)" = "aarch64" ]; then echo "linux/arm64"; else echo "linux/amd64"; fi) --load .
+	$(DOCKER_CMD) buildx build --tag $(DOCKER_IMAGE) --platform linux/amd64 --load .
 
 # Command: pulls latest docker image from dockerhub.  This will *replace* locally built version.
 docker-image-pull:


### PR DESCRIPTION
`make docker-image-build` fails with:
```
 > [ 3/15] RUN pacman -Syu --noconfirm:
0.117 :: Synchronizing package databases...
0.123 error: error restricting syscalls via seccomp: 22!
0.123 error: switching to sandbox user 'alpm' failed!
0.123 error: failed to synchronize all databases (failed to retrieve some files)
```

Current arclinux:latest base image uses newer pacman that sandboxes which fails in docker. This PR disables sandboxing.

Also this PR forces amd64 docker image, there is no arm64 archlinux base image so on arm64 we need to force amd64 docker build.