### PR TITLE
Add EE clone 640×480 MIPI plugin overlay (clone_panel_11)

### DIFF
--- a/config/archr-dts/R36S-clone-plugin-overlays/eeclone-mipi-panel-640x480.dts
+++ b/config/archr-dts/R36S-clone-plugin-overlays/eeclone-mipi-panel-640x480.dts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * MIPI panel overlay for RK3326 EE-clone handhelds with 640x480 (HVGA) panel
+ * and ST7703-style init via archr,generic-dsi.
+ *
+ * Applied on top of rk3326-gameconsole-eeclone.dtb (clone image).
+ * Contributors: community (Arch R)
+ */
+
+/dts-v1/;
+
+/ {
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+
+			dsi@ff450000 {
+
+				panel@0 {
+					compatible = "archr,generic-dsi";
+					panel_description = "G size=153,85 delays=20,20,20,120,20 format=rgb888 lanes=4 flags=0xe03\0M clock=30000 horizontal=640,150,50,150 vertical=480,20,6,12 default=1\0M clock=30000 horizontal=640,150,61,150 vertical=480,20,88,12\0M clock=30000 horizontal=640,150,60,150 vertical=480,20,88,12\0M clock=30010 horizontal=640,150,72,150 vertical=480,20,81,12\0M clock=30130 horizontal=640,150,60,150 vertical=480,20,12,12\0M clock=35920 horizontal=640,150,59,150 vertical=480,20,90,12\0M clock=31440 horizontal=640,150,61,150 vertical=480,20,12,12\0M clock=31080 horizontal=640,150,60,150 vertical=480,20,6,12\0M clock=32750 horizontal=640,150,96,150 vertical=480,20,14,12\0M clock=45250 horizontal=640,150,66,150 vertical=480,20,84,12\0M clock=46620 horizontal=640,150,60,150 vertical=480,20,6,12\0M clock=62160 horizontal=640,150,60,150 vertical=480,20,6,12\0I seq=b9f11283\0I seq=b1000000da80\0I seq=b2001370\0I seq=b31010282803ff00000000\0I seq=b480\0I seq=b50a0a\0I seq=b68282\0I seq=b82662f063\0I seq=ba338105f90e0e2000000000000000442500900a0000014f01000037\0I seq=bc47\0I seq=bf021100\0I seq=c0737350500000125000\0I seq=c15300323277d1cccc77773333\0I seq=c68200bfff00ff\0I seq=c7b8000a000000\0I seq=c810401e02\0I seq=cc0b\0I seq=e000070d37353f4144060c0d0f111012141a00070d37353f4144060c0d0f111012141a\0I seq=e307070b0b0b0b00000000ff00c010\0I seq=e9c810020000b0b11131232880b0b127080004020000000004020000008888ba60240888888888888888ba713518888888888800000001000000000000000000\0I seq=ea970a820203070000000000008188ba17538888888888888088ba0642888888888888230000028000000000000000000000000000000000000000000000\0I seq=efffff01\0I seq=11 wait=200\0I seq=29 wait=20";
+					reset-gpios = <0xffffffff 0x1b 0x01>;
+				};
+			};
+
+			pinctrl {
+
+				gpio-lcd {
+
+					lcd-rst {
+						rockchip,pins = <0x03 0x1b 0x00 0xffffffff>;
+					};
+				};
+
+				vcc18-lcd {
+
+					vcc18-lcd-n {
+						rockchip,pins = <0x03 0x03 0x00 0xffffffff>;
+					};
+				};
+			};
+
+			vcc18-lcd0 {
+				gpio = <0xffffffff 0x03 0x00>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+
+		__overlay__ {
+
+			adc-keys {
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <0xffffffff>;
+
+		__overlay__ {
+			invert-absx = <0x01>;
+			invert-absy = <0x01>;
+		};
+	};
+
+	fragment@3 {
+		target-path = "/";
+
+		__overlay__ {
+
+			audio-amplifier {
+				enable-gpios = <0xffffffff 0x07 0x00>;
+			};
+
+			pinctrl {
+
+				speaker {
+					spk-amp-enable-h {
+						rockchip,pins = <0x03 0x07 0x00 0xffffffff>;
+					};
+				};
+
+				headphone {
+					hp-det {
+						rockchip,pins = <0x02 0x16 0x00 0xffffffff>;
+					};
+				};
+			};
+
+			rk817-sound-amplified {
+				status = "okay";
+				simple-audio-card,hp-det-gpio = <0xffffffff 0x16 0x00>;
+			};
+		};
+	};
+
+	__fixups__ {
+		gpio3 = "/fragment@0/__overlay__/dsi@ff450000/panel@0:reset-gpios:0\0/fragment@0/__overlay__/vcc18-lcd0:gpio:0\0/fragment@3/__overlay__/audio-amplifier:enable-gpios:0";
+		pcfg_pull_none = "/fragment@0/__overlay__/pinctrl/gpio-lcd/lcd-rst:rockchip,pins:12\0/fragment@0/__overlay__/pinctrl/vcc18-lcd/vcc18-lcd-n:rockchip,pins:12\0/fragment@3/__overlay__/pinctrl/speaker/spk-amp-enable-h:rockchip,pins:12";
+		joypad = "/fragment@2:target:0";
+		gpio2 = "/fragment@3/__overlay__/rk817-sound-amplified:simple-audio-card,hp-det-gpio:0";
+		pcfg_pull_up = "/fragment@3/__overlay__/pinctrl/headphone/hp-det:rockchip,pins:12";
+	};
+};

--- a/config/mipi-generator/generator.sh
+++ b/config/mipi-generator/generator.sh
@@ -8,6 +8,8 @@
 # Sources:
 #   - R36S originals: DTS in config/archr-dts/R36S-DTB/DTS/
 #   - R36S clones: DTBs in config/archr-dts/R36S-Clones-DTB/
+#   - EE clone plugin overlays: hand-written overlay DTS in
+#     config/archr-dts/R36S-clone-plugin-overlays/ (compiled with dtc -@ only)
 #
 # Output:
 #   - output/panels/original/  -> overlays for original R36S image
@@ -106,6 +108,31 @@ generate_from_dtb() {
 }
 
 #------------------------------------------------------------------------------
+# Helper: compile overlay plugin DTS with dtc -@ (no archr-dtbo.py)
+#------------------------------------------------------------------------------
+generate_from_plugin_dts() {
+    local dts_file="$1"
+    local out_file="$2"
+    local label="$3"
+
+    if [ ! -f "$dts_file" ]; then
+        warn "  Plugin DTS not found: $dts_file"
+        FAILED=$((FAILED + 1))
+        return 1
+    fi
+
+    if dtc -I dts -O dtb -@ "$dts_file" -o "$out_file" 2>/dev/null; then
+        local sz=$(stat -c%s "$out_file")
+        log "  OK: $(basename "$out_file") (${sz} bytes) [$label]"
+        GENERATED=$((GENERATED + 1))
+    else
+        warn "  dtc failed plugin overlay: $(basename "$dts_file")"
+        FAILED=$((FAILED + 1))
+        return 1
+    fi
+}
+
+#------------------------------------------------------------------------------
 # Original R36S panels (DTS files)
 #------------------------------------------------------------------------------
 log "=== Original R36S Panel Overlays ==="
@@ -172,6 +199,28 @@ for key in "${CLONE_ORDER[@]}"; do
     dtb="${CLONE_PANELS[$key]}"
     log "Clone ${key}: ${dtb}"
     generate_from_dtb "$CLONES_DIR/$dtb" "$OUTPUT_CLONE/${key}.dtbo" "" "$key"
+done
+
+#------------------------------------------------------------------------------
+# Clone R36S — hand-written plugin overlays (dts → dtbo via dtc -@)
+#------------------------------------------------------------------------------
+PLUGIN_CLONE_DTS_DIR="${ROOT_DIR}/config/archr-dts/R36S-clone-plugin-overlays"
+log ""
+log "=== Clone EE plugin overlays (dtc -@) ==="
+log "Source: $PLUGIN_CLONE_DTS_DIR"
+log "Output: $OUTPUT_CLONE"
+log ""
+
+declare -A PLUGIN_CLONE_DTS=(
+    [clone_panel_11]="eeclone-mipi-panel-640x480.dts"
+)
+
+PLUGIN_CLONE_ORDER=(clone_panel_11)
+
+for key in "${PLUGIN_CLONE_ORDER[@]}"; do
+    dts="${PLUGIN_CLONE_DTS[$key]}"
+    log "Plugin clone ${key}: ${dts}"
+    generate_from_plugin_dts "$PLUGIN_CLONE_DTS_DIR/$dts" "$OUTPUT_CLONE/${key}.dtbo" "$key"
 done
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Adds a hand-written device-tree **plugin overlay** for RK3326 **EE clone** handhelds that use a **640×480 (HVGA)** MIPI panel with `archr,generic-dsi`, plus tuning for **audio** (amplified path / headphone detect) and related nodes on this hardware revision.

The overlay is built in `mipi-generator` with `dtc -@` only (no `archr-dtbo.py` extraction), and shipped as **`clone_panel_11.dtbo`** on the **clone** image alongside existing clone panel overlays.

### Changes

- New DTS: `config/archr-dts/R36S-clone-plugin-overlays/eeclone-mipi-panel-640x480.dts`
- `config/mipi-generator/generator.sh`: `generate_from_plugin_dts` + `PLUGIN_CLONE_*` map entry for `clone_panel_11`

### User-facing behavior

On the **clone** image, users with this panel variant can copy the generated overlay to the active MIPI overlay name used at boot (see `overlays/README.txt`), typically:

`overlays/clone_panel_11.dtbo` → `overlays/mipi-panel.dtbo`

### Testing

- [x] Built `clone_panel_11.dtbo` via `generator.sh` (requires `dtc`; full script also needs Python `fdt` for other panels)
- [x] Verified display and audio on EE clone hardware with this overlay applied

### Notes

- `config/mipi-generator/output/` remains gitignored; DTBOs are produced at build time.